### PR TITLE
javadoc site building2

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -109,7 +109,6 @@ fi
 #-----------------------------------------------------------------------------------------                   
 # Main logic.
 #-----------------------------------------------------------------------------------------                   
-
 source_dir="."
 
 project=$(basename ${BASEDIR})
@@ -150,7 +149,10 @@ log_file=${LOGS_DIR}/${project}.txt
 info "Log will be placed at ${log_file}"
 date > ${log_file}
 
+
+#------------------------------------------------------------------------------------
 h2 "Checking dependencies are present..."
+#------------------------------------------------------------------------------------
 declare -a required_files=(
 ${WORKSPACE_DIR}/${project}/dev.galasa.uber.obr/pom.template
 ${WORKSPACE_DIR}/framework/release.yaml 
@@ -167,8 +169,10 @@ do
     fi
 done
 
-h2 "Generating a pom.xml from a template, using all the versions of everything..."
 
+#------------------------------------------------------------------------------------
+h2 "Generating a pom.xml from a template, using all the versions of everything..."
+#------------------------------------------------------------------------------------
 cat << EOF >> ${log_file}
 Using command:
 
@@ -237,7 +241,9 @@ fi
 success "pom.xml built ok - log is at ${log_file}"
 
 
+#------------------------------------------------------------------------------------
 h2 "Building the generated pom.xml to package-up things into an OBR we can publish..."
+#------------------------------------------------------------------------------------
 mvn \
 -Dgpg.passphrase=${GPG_PASSPHRASE} \
 -Dgalasa.source.repo=${SOURCE_MAVEN} \
@@ -248,5 +254,57 @@ rc=$? ; if [[ "${rc}" != "0" ]]; then
     error "Failed to push built obr into maven repo ${project}" 
     exit 1 
 fi
+success "OK"
+
+#------------------------------------------------------------------------------------
+h1 "Building the javadoc using the OBR..."
+#------------------------------------------------------------------------------------
+
+
+#------------------------------------------------------------------------------------
+h2 "Generate a pom.xml we can use with the javadoc"
+#------------------------------------------------------------------------------------
+cd ${WORKSPACE_DIR}/obr/javadocs
+
+${GALASA_BUILD_TOOL_PATH} template \
+--releaseMetadata ${WORKSPACE_DIR}/framework/release.yaml \
+--releaseMetadata ${WORKSPACE_DIR}/extensions/release.yaml \
+--releaseMetadata ${WORKSPACE_DIR}/managers/release.yaml \
+--releaseMetadata ${WORKSPACE_DIR}/obr/release.yaml \
+--template pom.template \
+--output pom.xml \
+--javadoc 
+
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to create the pom.xml for javadoc" ;  exit 1 ; fi
+success "OK - pom.xml file created at ${WORKSPACE_DIR}/obr/javadocs/pom.xml"
+
+
+#------------------------------------------------------------------------------------
+h2 "Building the javadoc with maven"
+#------------------------------------------------------------------------------------
+cd ${WORKSPACE_DIR}/obr/javadocs
+mvn clean install -X \
+--settings ${WORKSPACE_DIR}/obr/settings.xml \
+--batch-mode \
+--errors \
+--fail-at-end \
+-Dgpg.skip=true \
+-Dgalasa.source.repo=${SOURCE_MAVEN} \
+-Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+-Dmaven.javadoc.failOnError=true
+
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "maven failed for javadoc build" ;  exit 1 ; fi
+
+success "OK - Build the galasa-uber-javadoc-*.zip file:"
+ls ${WORKSPACE_DIR}/obr/javadocs/target/*.zip
+
+# #------------------------------------------------------------------------------------
+# h2 "Packaging the javadoc into a docker file"
+# #------------------------------------------------------------------------------------
+# cd ${WORKSPACE_DIR}/obr/javadocs
+# docker --file ${WORKSPACE_DIR}/automation/dockerfiles/javadocs/javadocs-image-dockerfile .
+   
+# rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to create the docker image containing the javadoc" ;  exit 1 ; fi
+# success "OK"
 
 success "Project ${project} built - OK - log is at ${log_file}"

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -283,7 +283,7 @@ success "OK - pom.xml file created at ${WORKSPACE_DIR}/obr/javadocs/pom.xml"
 h2 "Building the javadoc with maven"
 #------------------------------------------------------------------------------------
 cd ${WORKSPACE_DIR}/obr/javadocs
-mvn clean install -X \
+mvn clean install \
 --settings ${WORKSPACE_DIR}/obr/settings.xml \
 --batch-mode \
 --errors \

--- a/javadocs/pom.template
+++ b/javadocs/pom.template
@@ -43,7 +43,19 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
 				<executions>
+                    <execution>
+						<id>gather-dependent-jars</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>unpack-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <excludeGroupIds>dev.galasa</excludeGroupIds>
+						</configuration>
+					</execution>
 					<execution>
 						<id>unpack</id>
 						<phase>generate-sources</phase>
@@ -58,22 +70,30 @@
 					</execution>
 				</executions>
 			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.1</version>
 				<executions>
 					<execution>
 						<phase>compile</phase>
 						<id>attach-javadocs</id>
 						<goals>
-							<goal>javadoc-no-fork</goal>
+							<goal>javadoc</goal>
 						</goals>
 					</execution>
 				</executions>
 				<configuration>
 					<failOnError>false</failOnError>
+                    <debug>false</debug>
+                    <classpath>${project.build.directory}/classes</classpath>
 					<sourcepath>${project.build.directory}/sources</sourcepath>
-					<excludePackageNames>*.ivt:*.internal.*:*.internal:dev.galasa.framework.maven.repository.spi</excludePackageNames>
+					<excludePackageNames>*.ivt:*.internal.*:*.internal:dev.galasa.framework.maven.repository.spi:OSGI-OPT.*</excludePackageNames>
+                    <additionalOptions>
+                        -classpath
+                        '${project.build.directory}/classes'
+                    </additionalOptions>
 					<tags>
                         <tag>
                             <name>galasa.annotation</name>

--- a/javadocs/pom.template
+++ b/javadocs/pom.template
@@ -87,12 +87,12 @@
 				<configuration>
 					<failOnError>false</failOnError>
                     <debug>false</debug>
-                    <classpath>${project.build.directory}/classes</classpath>
 					<sourcepath>${project.build.directory}/sources</sourcepath>
 					<excludePackageNames>*.ivt:*.internal.*:*.internal:dev.galasa.framework.maven.repository.spi:OSGI-OPT.*</excludePackageNames>
                     <additionalOptions>
                         -classpath
                         '${project.build.directory}/classes'
+                        --frames
                     </additionalOptions>
 					<tags>
                         <tag>


### PR DESCRIPTION
- javadoc site wasnt building. Attempting fix 1.
- build javadoc zip using local build
- Remove debug from javadoc build


The build process was failing in the maven build because not all of the transitive dependency jars were available to the javadoc commmand, so the javadoc tool was failing with 'symbol not found' errors all over the place.

The fix is to pull-down all the dependent jars, unpack them into a `target/classes` folder, and make sure there are no `.java` files in that location.

Next fix was to add the `target/classes` to the `-classpath` in the arguments file that gets built-up for the javadoc tool to use (by the `maven-javadoc-plugin`)

Then when the javadoc tool gets executed, it can resolve any symbols it needs to while rendering the javadoc.

Once that happens, the maven pom.xml is all set to zip-up the archive and the build process should be un-packing the contents into a docker image to be served up and hosted ?
I'm not sure of the following steps yet, but it might help if we have the site content included inside the zip and go after that piece of the puzzle next...


---

After a HUGE amount of fiddling around, I think I 'may' have a temporary solution to building the javadoc site content.
I'd be interested to see if this works.

There's a huge amount of messing around with this stuff to get it working I think, mostly because of coding decisions made along the way, not splitting internals from external interfaces correctly in the entire codebase... but we won't be fixing that in a hurry I think.

So... how to we see if this builds overall ?

I think there is little risk of making it worse than it already is... considering the javadoc build output doesn't work right now.

I note there are several things like <failOnError>false</failOnError> in the code/external/galasa-dev/obr/javadocs/pom.template file...
These need to be removed, but the javadoc is sooo buggy right now that will cause it to fail completely. (It was like that before I got here).

The concept of generating a maven pom file to do the javadoc stuff is a tad bizarre/too clever for it's own good, and this layer of indirection introduces needless complexity I think. But it is what it is...