### PR TITLE
Revert http jetty update

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -197,7 +197,7 @@ external:
     
   - group: org.apache.felix
     artifact: org.apache.felix.http.jetty
-    version: 4.2.2
+    version: 4.0.14
     obr: true
     isolated: true
     


### PR DESCRIPTION
Update needs more investigation as it prevents the felix framework from starting.