### PR TITLE
Bump jetty to 5.0.0 and servlet-api to 2.1.0

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -197,7 +197,7 @@ external:
     
   - group: org.apache.felix
     artifact: org.apache.felix.http.jetty
-    version: 4.0.14
+    version: 4.2.2
     obr: true
     isolated: true
     

--- a/release.yaml
+++ b/release.yaml
@@ -197,7 +197,7 @@ external:
     
   - group: org.apache.felix
     artifact: org.apache.felix.http.jetty
-    version: 4.2.2
+    version: 5.0.0
     obr: true
     isolated: true
     

--- a/release.yaml
+++ b/release.yaml
@@ -190,7 +190,7 @@ external:
     
   - group: org.apache.felix
     artifact: org.apache.felix.http.servlet-api
-    version: 1.1.2
+    version: 2.1.0
     obr: true
     mvp: true
     isolated: true


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1089