### PR TITLE
Remove --frames option so we can migrate to java 17 version of javadoc.

### DIFF
--- a/javadocs/pom.template
+++ b/javadocs/pom.template
@@ -92,7 +92,6 @@
                     <additionalOptions>
                         -classpath
                         '${project.build.directory}/classes'
-                        --frames
                     </additionalOptions>
 					<tags>
                         <tag>


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
