### PR TITLE
re-add developer attribution in galasa bom to satisfy maven central checks.

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -240,6 +240,20 @@ if [[ "${rc}" != "0" ]]; then
 fi
 success "pom.xml built ok - log is at ${log_file}"
 
+#------------------------------------------------------------------------------------
+function check_developer_attribution_present {
+    h2 "Checking that pom has developer attribution."
+    cat ${BASEDIR}/galasa-bom/pom.template | grep "<developers>" >> /dev/null
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error "The pom.template must have developer attribution inside. \
+        This is needed so that we can publish artifacts to maven central."
+        exit 1
+    fi
+    success "OK. Pom template contains developer attribution, which maven central needs at the point we publish."
+}
+
+check_developer_attribution_present
 
 #------------------------------------------------------------------------------------
 h2 "Building the generated pom.xml to package-up things into an OBR we can publish..."
@@ -306,5 +320,7 @@ ls ${WORKSPACE_DIR}/obr/javadocs/target/*.zip
    
 # rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to create the docker image containing the javadoc" ;  exit 1 ; fi
 # success "OK"
+
+
 
 success "Project ${project} built - OK - log is at ${log_file}"

--- a/galasa-bom/pom.template
+++ b/galasa-bom/pom.template
@@ -20,57 +20,6 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <name>Michael Baylis</name>
-            <email>Michael.Baylis@uk.ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-        <developer>
-            <name>William Yates</name>
-            <email>wyates@uk.ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-        <developer>
-            <name>David Roberts</name>
-            <email>david.roberts@uk.ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-        <developer>
-            <name>James Davies</name>
-            <email>james.davies@ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-        <developer>
-            <name>Matthew Chivers</name>
-            <email>matthew.chivers@ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-        <developer>
-            <name>Jade Carino</name>
-            <email>jade.carino@ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-        <developer>
-            <name>Charlie Meek</name>
-            <email>charlie.meek@ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-        <developer>
-            <name>Diana Slepikaite</name>
-            <email>diana.slepikaite@ibm.com</email>
-            <organization>IBM</organization>
-            <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>
-    </developers>
-
     <scm>
         <url>https://github.com/galasa-dev/framework</url>
         <connection>scm:git:git:://github.com/galasa-dev/framework</connection>

--- a/galasa-bom/pom.template
+++ b/galasa-bom/pom.template
@@ -20,6 +20,58 @@
         </license>
     </licenses>
 
+    <!-- Note: Maven central requires developer attribution. Do not remove this section. -->
+    <developers>
+        <developer>
+            <name>Michael Baylis</name>
+            <email>Michael.Baylis@uk.ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>William Yates</name>
+            <email>wyates@uk.ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>David Roberts</name>
+            <email>david.roberts@uk.ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>James Davies</name>
+            <email>james.davies@ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Matthew Chivers</name>
+            <email>matthew.chivers@ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Jade Carino</name>
+            <email>jade.carino@ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Charlie Meek</name>
+            <email>charlie.meek@ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Diana Slepikaite</name>
+            <email>diana.slepikaite@ibm.com</email>
+            <organization>IBM</organization>
+            <organizationUrl>https://www.ibm.com</organizationUrl>
+        </developer>
+    </developers>
+
     <scm>
         <url>https://github.com/galasa-dev/framework</url>
         <connection>scm:git:git:://github.com/galasa-dev/framework</connection>

--- a/release.yaml
+++ b/release.yaml
@@ -250,18 +250,18 @@ external:
     isolated: true
 
   - group: org.bouncycastle 
-    artifact: bcpkix-jdk15on 
-    version: 1.69
+    artifact: bcpkix-jdk18on 
+    version: 1.75
     obr: true
 
   - group: org.bouncycastle 
-    artifact: bcprov-jdk15on 
-    version: 1.69
+    artifact: bcprov-jdk18on 
+    version: 1.75
     obr: true
 
   - group: org.bouncycastle 
-    artifact: bcutil-jdk15on 
-    version: 1.69
+    artifact: bcutil-jdk18on 
+    version: 1.75
     obr: true
 
   - group: org.slf4j


### PR DESCRIPTION
- Developer attribution required in maven. Clashes with IBM normal policy to not publish developer attribution, so was previously removed. Re-added so we can get artifacts published to maven central.
