### PR TITLE
build-locally.sh pointed to wrong yaml dependencies

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -176,8 +176,10 @@ function download_dependencies {
 function check_dependencies_present {
     h2 "Checking dependencies are present..."
 
-    export framework_manifest_path=${BASEDIR}/dependency-download/build/dependencies/dev.galasa.framework.manifest.yaml
-    export managers_manifest_path=${BASEDIR}/dependency-download/build/dependencies/dev.galasa.managers.manifest.yaml
+    # export framework_manifest_path=${BASEDIR}/dependency-download/build/dependencies/dev.galasa.framework.manifest.yaml
+    # export managers_manifest_path=${BASEDIR}/dependency-download/build/dependencies/dev.galasa.managers.manifest.yaml
+    export framework_manifest_path=${WORKSPACE_DIR}/framework/release.yaml
+    export managers_manifest_path=${WORKSPACE_DIR}/managers/release.yaml
     
     declare -a required_files=(
     ${WORKSPACE_DIR}/${project}/dev.galasa.uber.obr/pom.template


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Some debris from a failed attempt at renovating the release.yaml processing was left in the build-locally.sh script.

Corrected it.