### PR TITLE
bumped version of commons-compress in release.yaml

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -160,7 +160,7 @@ external:
 
   - group: org.apache.commons
     artifact: commons-compress
-    version: 1.21
+    version: 1.26.0
     obr: true
     mvp: true
     isolated: true

--- a/release.yaml
+++ b/release.yaml
@@ -55,7 +55,7 @@ external:
 
   - group: commons-io
     artifact: commons-io
-    version: 2.9.0
+    version: 2.16.1
     obr: true
     bom: true
     mvp: true
@@ -167,7 +167,7 @@ external:
 
   - group: org.apache.commons
     artifact: commons-lang3
-    version: 3.12.0
+    version: 3.14.0
     obr: true
     bom: true
     mvp: true


### PR DESCRIPTION
## Why?

This change is needed in order to resolve the vulnerabilities within the commons-compress package at version 1.21. to resolve this the package needs to be bumped up to version 1.26.0 along with it's dependencies.