### PR TITLE
mcobbett build bom locally

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -252,7 +252,7 @@ function construct_bom_pom_xml {
     --releaseMetadata ${WORKSPACE_DIR}/obr/release.yaml \
     --template pom.template \
     --output pom.xml \
-    --obr \
+    --bom \
     "
     echo "Command is $cmd" >> ${log_file}
     $cmd 2>&1 >> ${log_file}


### PR DESCRIPTION

## Why ?
The local build process was generating a pom.xml in the galasa-bom folder, but was using the wrong option on the build tool, so it ended up not taking notice that the commons-logging package isn't in the obr, but is in the bom.

That explained why it was missing from the bom.

Working in this area as a result of [Local test run to be able to use remote CPS
#1813](https://github.com/galasa-dev/projectmanagement/issues/1813)
