### PR TITLE
bumped version to 0.34.0

### DIFF
--- a/dependency-download/build.gradle
+++ b/dependency-download/build.gradle
@@ -7,7 +7,7 @@ plugins {
 // It is used as the version number of the managers bundle, which contains a yaml
 // file which is in a release.yaml, but published to maven, so that the OBR build 
 // can pick it up later.
-version = "0.33.0"
+version = "0.34.0"
 
 repositories {
     mavenLocal()

--- a/release.yaml
+++ b/release.yaml
@@ -12,7 +12,7 @@ metadata:
 
 
 release:
-  version: 0.33.0
+  version: 0.34.0
 
 
 


### PR DESCRIPTION
## Why? 
 As part of the release process the development version numbers need to be bumped to the next version