### PR TITLE
Bump maven plugin to 0.34.0

### DIFF
--- a/dev.galasa.uber.obr/pom.template
+++ b/dev.galasa.uber.obr/pom.template
@@ -66,7 +66,7 @@
 			<plugin>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-maven-plugin</artifactId>
-				<version>0.17.0</version>
+				<version>0.34.0</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/galasa-bom/pom.template
+++ b/galasa-bom/pom.template
@@ -59,7 +59,7 @@
 				<plugin>
 					<groupId>dev.galasa</groupId>
 					<artifactId>galasa-maven-plugin</artifactId>
-					<version>0.17.0</version>
+					<version>0.34.0</version>
 				</plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Why?
Follow-on from changes in https://github.com/galasa-dev/maven/pull/118

Note: Builds for this PR will fail until the above PR is merged

## Changes
- Bumped the Galasa maven plugin from 0.17.0 to 0.34.0 in the uber OBR and galasa BOM