### PR TITLE
Iss1897 - Upgrade version of the JTA wrapper we ship

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -92,7 +92,7 @@ external:
 
   - group: dev.galasa
     artifact: jta
-    version: 1.1
+    version: 1.2
     obr: true
     mvp: true
     isolated: true
@@ -103,14 +103,6 @@ external:
     obr: true
     mvp: true
     isolated: true
-
-  # - group: dev.galasa
-  #   artifact: kafka.clients
-  #   version: 3.7.0
-  #   obr: true
-  #   bom: true
-  #   isolated: true
-  #   mvp: true
 
   - group: io.prometheus
     artifact: simpleclient

--- a/release.yaml
+++ b/release.yaml
@@ -104,6 +104,14 @@ external:
     mvp: true
     isolated: true
 
+  # - group: dev.galasa
+  #   artifact: kafka.clients
+  #   version: 3.7.0
+  #   obr: true
+  #   bom: true
+  #   isolated: true
+  #   mvp: true
+
   - group: io.prometheus
     artifact: simpleclient
     version: 0.6.0


### PR DESCRIPTION
### Why?

For story https://github.com/galasa-dev/projectmanagement/issues/1897

Without upgrading the release.yaml, the changes to the wrapper won't get shipped.