### PR TITLE
updated gradle methods to work for 8.8

### DIFF
--- a/dependency-download/build.gradle
+++ b/dependency-download/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-    runtime group: 'dev.galasa', name: 'dev.galasa.managers.manifest', version: version, ext: "yaml"
-    runtime group: 'dev.galasa', name: 'dev.galasa.framework.manifest', version: version, ext: "yaml"
+    runtimeOnly group: 'dev.galasa', name: 'dev.galasa.managers.manifest', version: version, ext: "yaml"
+    runtimeOnly group: 'dev.galasa', name: 'dev.galasa.framework.manifest', version: version, ext: "yaml"
 }
 
 // Download all the files we depend upon.
@@ -32,6 +32,7 @@ task downloadAllDependencies(type: Copy) {
 
 // Gets the manager dependency and renames it to remove the version number.
 task getManagerDependency(type: Copy) {
+    dependsOn downloadAllDependencies
     from 'build/dependencies'
     include "dev.galasa.managers.manifest-${version}.yaml"
     destinationDir file('build/dependencies/')
@@ -40,6 +41,8 @@ task getManagerDependency(type: Copy) {
 
 // Gets the framework dependency and renames it to remove the version number.
 task getFrameworkDependency(type: Copy) {
+    dependsOn downloadAllDependencies
+    dependsOn getManagerDependency
     from 'build/dependencies'
     include "dev.galasa.framework.manifest-${version}.yaml"
     destinationDir file('build/dependencies/')


### PR DESCRIPTION
# Why
Java is outdated on this branch, upgrading to latest version, relates to: https://github.com/galasa-dev/projectmanagement/issues/1823