### PR TITLE
Add support for Gradle 8

### DIFF
--- a/dependency-download/build.gradle
+++ b/dependency-download/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-    runtime group: 'dev.galasa', name: 'dev.galasa.managers.manifest', version: version, ext: "yaml"
-    runtime group: 'dev.galasa', name: 'dev.galasa.framework.manifest', version: version, ext: "yaml"
+    runtimeOnly group: 'dev.galasa', name: 'dev.galasa.managers.manifest', version: version, ext: "yaml"
+    runtimeOnly group: 'dev.galasa', name: 'dev.galasa.framework.manifest', version: version, ext: "yaml"
 }
 
 // Download all the files we depend upon.
@@ -31,19 +31,29 @@ task downloadAllDependencies(type: Copy) {
 }
 
 // Gets the manager dependency and renames it to remove the version number.
-task getManagerDependency(type: Copy) {
-    from 'build/dependencies'
-    include "dev.galasa.managers.manifest-${version}.yaml"
-    destinationDir file('build/dependencies/')
-    rename "dev.galasa.managers.manifest-${version}.yaml", "dev.galasa.managers.manifest.yaml"
+task getManagerDependency {
+    dependsOn downloadAllDependencies
+    doFirst {
+        copyDependency("dev.galasa.managers.manifest-${version}.yaml", "dev.galasa.managers.manifest.yaml")
+    }
 }
 
 // Gets the framework dependency and renames it to remove the version number.
-task getFrameworkDependency(type: Copy) {
-    from 'build/dependencies'
-    include "dev.galasa.framework.manifest-${version}.yaml"
-    destinationDir file('build/dependencies/')
-    rename "dev.galasa.framework.manifest-${version}.yaml", "dev.galasa.framework.manifest.yaml"
+task getFrameworkDependency {
+    dependsOn downloadAllDependencies
+    doFirst {
+        copyDependency("dev.galasa.framework.manifest-${version}.yaml", "dev.galasa.framework.manifest.yaml")
+    }
+}
+
+// Creates a copy of a dependency matching the given pattern and renames it with the given name
+def copyDependency(dependencyPattern, desiredFileName) {
+    copy {
+        from 'build/dependencies'
+        include dependencyPattern
+        into file('build/dependencies/')
+        rename dependencyPattern, desiredFileName
+    }
 }
 
 // Gets all the dependencies


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1652

Fixed build errors when using Gradle 8 in the dependency-download project