### PR TITLE
Upgrade the dependency on a later wrapped jwt bundle

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -85,7 +85,7 @@ external:
 
   - group: dev.galasa
     artifact: com.auth0.jwt
-    version: 4.4.0
+    version: 4.4.1
     obr: true
     mvp: true
     isolated: true


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
The auth0.jwt bundle was upgraded, so we need to refer to the latest version. 4.4.1
