### PR TITLE
Parameterise main build workflow to support any branch/tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,14 @@ env:
   ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
 
 jobs:
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+          
   build-obr:
     name: Build OBR using galasabld image and maven
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,8 @@ on:
 env:
   REGISTRY: ghcr.io
   NAMESPACE: galasa-dev
-  IMAGE_TAG: main
+  BRANCH: ${{ github.ref_name }}
+  ARGO_APP_BRANCH: gh # TODO: remove this parameter and just use env.BRANCH once we update development.galasa.dev/main with these workflows.
   ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
 
 jobs:
@@ -21,24 +22,28 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: obr
+          ref: ${{ env.BRANCH }}
     
       - name: Checkout framework
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/framework
           path: framework
+          ref: ${{ env.BRANCH }}
 
       - name: Checkout extensions
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/extensions
           path: extensions
+          ref: ${{ env.BRANCH }}
       
       - name: Checkout managers
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/managers
           path: managers
+          ref: ${{ env.BRANCH }}
       
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -89,7 +94,7 @@ jobs:
       
       - name:  Generate Galasa BOM
         run: |
-          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:${{ env.IMAGE_TAG }} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/galasa-bom/pom.template --output /var/root/obr/galasa-bom/pom.xml --bom
+          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/galasa-bom/pom.template --output /var/root/obr/galasa-bom/pom.xml --bom
           
       - name: Display Galasa BOM pom.xml
         run: |
@@ -98,7 +103,7 @@ jobs:
       - name: Build Galasa BOM with maven
         run: |
           mvn -f ${{ github.workspace }}/obr/galasa-bom/pom.xml deploy \
-          -Dgalasa.source.repo=https://development.galasa.dev/gh/maven-repo/managers \
+          -Dgalasa.source.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/managers \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/obr/repo \
           --batch-mode --errors --fail-at-end \
@@ -106,7 +111,7 @@ jobs:
       
       - name:  Generate Galasa OBR
         run: |
-          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:${{ env.IMAGE_TAG }} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/dev.galasa.uber.obr/pom.template --output /var/root/obr/dev.galasa.uber.obr/pom.xml --obr
+          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/dev.galasa.uber.obr/pom.template --output /var/root/obr/dev.galasa.uber.obr/pom.xml --obr
           
       - name: Display Galasa OBR pom.xml
         run: |
@@ -115,7 +120,7 @@ jobs:
       - name: Build Galasa OBR with maven
         run: |
           mvn -f ${{ github.workspace }}/obr/dev.galasa.uber.obr/pom.xml deploy \
-          -Dgalasa.source.repo=https://development.galasa.dev/gh/maven-repo/managers \
+          -Dgalasa.source.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/managers \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/obr/repo \
           --batch-mode --errors --fail-at-end \
@@ -145,15 +150,15 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             dockerRepository=${{ env.REGISTRY }}
-            tag=${{ env.IMAGE_TAG }}
+            tag=${{ env.BRANCH }}
       
       - name: Recycle OBR application in ArgoCD
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run gh-maven-repos restart --kind Deployment --resource-name obr-gh --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.ARGO_APP_BRANCH }}-maven-repos restart --kind Deployment --resource-name obr-${{ env.ARGO_APP_BRANCH }} --server argocd.galasa.dev
 
       - name: Wait for OBR application health in ArgoCD
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait gh-maven-repos --resource apps:Deployment:obr-gh --health --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.ARGO_APP_BRANCH }}-maven-repos --resource apps:Deployment:obr-${{ env.ARGO_APP_BRANCH }} --health --server argocd.galasa.dev
 
   build-obr-javadocs:
     name: Build OBR javadocs using galasabld image and maven
@@ -164,24 +169,28 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: obr
+          ref: ${{ env.BRANCH }}
     
       - name: Checkout framework
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/framework
           path: framework
+          ref: ${{ env.BRANCH }}
 
       - name: Checkout extensions
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/extensions
           path: extensions
+          ref: ${{ env.BRANCH }}
 
       - name: Checkout managers
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/managers
           path: managers
+          ref: ${{ env.BRANCH }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -227,7 +236,7 @@ jobs:
           
       - name: Build Galasa Javadoc
         run: |
-            docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:${{ env.IMAGE_TAG }} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
+            docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
             
       - name: Display Galasa Javadoc pom.xml 
         run: |
@@ -236,7 +245,7 @@ jobs:
       - name: Build javadoc site using maven
         run: |
           mvn -f ${{ github.workspace }}/obr/javadocs/pom.xml deploy \
-          -Dgalasa.source.repo=https://development.galasa.dev/gh/maven-repo/managers \
+          -Dgalasa.source.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/managers \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgalasa.release.repo=file:${{ github.workspace }}/obr/javadocs/docker/repo \
           -Dmaven.javadoc.failOnError=false --batch-mode --errors --fail-at-end \
@@ -267,11 +276,11 @@ jobs:
       
       - name: Recycle javadocsite application in ArgoCD
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run gh-maven-repos restart --kind Deployment --resource-name javadocsite-gh --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.ARGO_APP_BRANCH }}-maven-repos restart --kind Deployment --resource-name javadocsite-${{ env.ARGO_APP_BRANCH }} --server argocd.galasa.dev
       
       - name: Wait for javadocsite application health in ArgoCD
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait gh-maven-repos --resource apps:Deployment:javadocsite-gh --health --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.ARGO_APP_BRANCH }}-maven-repos --resource apps:Deployment:javadocsite-${{ env.ARGO_APP_BRANCH }} --health --server argocd.galasa.dev
       
       - name: Extract metadata for Javadoc Maven repo image
         id: metadata
@@ -294,11 +303,11 @@ jobs:
           
       - name: Recycle javadoc application in ArgoCD
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run gh-maven-repos restart --kind Deployment --resource-name javadoc-gh --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.ARGO_APP_BRANCH }}-maven-repos restart --kind Deployment --resource-name javadoc-${{ env.ARGO_APP_BRANCH }} --server argocd.galasa.dev
 
       - name: Wait for javadoc application health in ArgoCD
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait gh-maven-repos --resource apps:Deployment:javadoc-gh --health --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.ARGO_APP_BRANCH }}-maven-repos --resource apps:Deployment:javadoc-${{ env.ARGO_APP_BRANCH }} --health --server argocd.galasa.dev
 
   build-obr-generic:
     name: Build OBR embedded and boot images using galasabld and maven
@@ -310,24 +319,28 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: obr
+          ref: ${{ env.BRANCH }}
       
       - name: Checkout framework
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/framework
           path: framework
+          ref: ${{ env.BRANCH }}
         
       - name: Checkout extensions
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/extensions
           path: extensions
+          ref: ${{ env.BRANCH }}
 
       - name: Checkout managers
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/managers
           path: managers
+          ref: ${{ env.BRANCH }}
 
       - name: Make secrets directory
         run : |
@@ -366,7 +379,7 @@ jobs:
       
       - name:  Generate Galasa OBR generic pom.xml
         run: |
-          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:${{ env.IMAGE_TAG }} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/obr-generic/pom.template --output /var/root/obr/obr-generic/pom.xml --obr
+          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/obr-generic/pom.template --output /var/root/obr/obr-generic/pom.xml --obr
            
       - name: Display Galasa OBR generic pom.xml
         run: |
@@ -376,7 +389,7 @@ jobs:
         working-directory: ${{ github.workspace }}/obr/obr-generic
         run: |
           mvn -f pom.xml process-sources \
-          -Dgalasa.source.repo=https://development.galasa.dev/gh/maven-repo/obr \
+          -Dgalasa.source.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           dev.galasa:galasa-maven-plugin:0.15.0:obrembedded \
           --batch-mode --errors --fail-at-end \
@@ -427,10 +440,9 @@ jobs:
           push: true
           tags: ${{ steps.metadata-boot-embedded.outputs.tags }}
           labels: ${{ steps.metadata-boot-embedded.outputs.labels }}
-          # These need updating...
           build-args: |
-            tag=${{env.IMAGE_TAG}}
-            dockerRepository=${{env.REGISTRY}}
+            tag=${{ env.BRANCH }}
+            dockerRepository=${{ env.REGISTRY }}
             jdkImage=harbor.galasa.dev/docker_proxy_cache/library/openjdk:11
 
       - name: Extract metadata for Galasa IBM boot embedded image
@@ -448,8 +460,7 @@ jobs:
           push: true
           tags: ${{ steps.metadata-ibm-boot-embedded.outputs.tags }}
           labels: ${{ steps.metadata-ibm-boot-embedded.outputs.labels }}
-          # These need updating...
           build-args: |
-            tag=${{env.IMAGE_TAG}}
-            dockerRepository=${{env.REGISTRY}}
+            tag=${{ env.BRANCH }}
+            dockerRepository=${{ env.REGISTRY }}
             platform=x86_64

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -10,6 +10,7 @@ env:
   IMAGE_TAG: main
   
 jobs:
+
   build-obr:
     name: Build OBR using galasabld image and maven
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why?

Contributes to issue https://github.com/galasa-dev/projectmanagement/issues/1958 - parameterising the build workflow to support any branch/tag.

Removed parameters for when we run the `galasabld` and `argocdcli` images as they will always be from ghcr.io/galasa-dev/xxx:main.