### PR TITLE
Fixed GALASA_BUILD_TOOL_NAME command based on OS

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -172,7 +172,24 @@ function get_galasabld_binary_location {
     if [ $ARCHITECTURE == "x86_64" ]; then
         export ARCHITECTURE="amd64"
     fi
-    export GALASA_BUILD_TOOL_NAME=galasabld-darwin-${ARCHITECTURE}
+
+    raw_os=$(uname -s) # eg: "Darwin"
+    os=""
+    case $raw_os in
+        Darwin*)
+            os="darwin"
+            ;;
+        Windows*)
+            os="windows"
+            ;;
+        Linux*)
+            os="linux"
+            ;;
+        *)
+            error "Failed to recognise which operating system is in use. $raw_os"
+            exit 1
+    esac
+    export GALASA_BUILD_TOOL_NAME=galasabld-${os}-${ARCHITECTURE}
 
     # Favour the galasabld tool if it's on the path, else use a locally-built version or fail if not available.
     GALASABLD_ON_PATH=$(which galasabld)


### PR DESCRIPTION
This change on the build build-locally.sh validate the OS where it was called and calls the right galasabld-xxx binary:

buildutils/bin/galasabld-linux-amd64
buildutils/bin/galasabld-windows-amd64
buildutils/bin/galasabld-darwin-amd64
buildutils/bin/galasabld-linux-s390x
buildutils/bin/galasabld-darwin-arm64

Attach testing output:

BUILD SUCCESSFUL in 3s
18 actionable tasks: 18 executed
✔ OK
