### PR TITLE
OBR script changes

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -93,9 +93,9 @@ function check_exit_code () {
     # This function takes 3 parameters in the form:
     # $1 an integer value of the returned exit code
     # $2 an error message to display if $1 is not equal to 0
-    if [[ "$1" != "0" ]]; then 
-        error "$2" 
-        exit 1  
+    if [[ "$1" != "0" ]]; then
+        error "$2"
+        exit 1
     fi
 }
 
@@ -276,7 +276,7 @@ function construct_bom_pom_xml {
 
 
     # Check local build version
-    export GALASA_BUILD_TOOL_PATH=${WORKSPACE_DIR}/buildutils/bin/${GALASA_BUILD_TOOL_NAME}
+    #export GALASA_BUILD_TOOL_PATH=${WORKSPACE_DIR}/buildutils/bin/${GALASA_BUILD_TOOL_NAME}
     info "Using galasabld tool ${GALASA_BUILD_TOOL_PATH}"
 
     cmd="${GALASA_BUILD_TOOL_PATH} template \
@@ -306,7 +306,7 @@ function construct_uber_obr_pom_xml {
     cd ${WORKSPACE_DIR}/${project}/dev.galasa.uber.obr
 
     # Check local build version
-    export GALASA_BUILD_TOOL_PATH=${WORKSPACE_DIR}/buildutils/bin/${GALASA_BUILD_TOOL_NAME}
+    #export GALASA_BUILD_TOOL_PATH=${WORKSPACE_DIR}/buildutils/bin/${GALASA_BUILD_TOOL_NAME}
     info "Using galasabld tool ${GALASA_BUILD_TOOL_PATH}"
 
     cmd="${GALASA_BUILD_TOOL_PATH} template \
@@ -349,6 +349,8 @@ function build_generated_bom_pom {
     cd ${BASEDIR}/galasa-bom
 
     mvn \
+    --settings ${WORKSPACE_DIR}/obr/settings.xml \
+    -Dgpg.skip=true \
     -Dgpg.passphrase=${GPG_PASSPHRASE} \
     -Dgalasa.source.repo=${SOURCE_MAVEN} \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ install \
@@ -367,6 +369,8 @@ function build_generated_uber_obr_pom {
     cd ${BASEDIR}/dev.galasa.uber.obr
 
     mvn \
+    --settings ${WORKSPACE_DIR}/obr/settings.xml \
+    -Dgpg.skip=true \
     -Dgpg.passphrase=${GPG_PASSPHRASE} \
     -Dgalasa.source.repo=${SOURCE_MAVEN} \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ install \
@@ -425,21 +429,21 @@ function check_secrets {
     h2 "updating secrets baseline"
     cd ${BASEDIR}
     detect-secrets scan --update .secrets.baseline
-    rc=$? 
-    check_exit_code $rc "Failed to run detect-secrets. Please check it is installed properly" 
+    rc=$?
+    check_exit_code $rc "Failed to run detect-secrets. Please check it is installed properly"
     success "updated secrets file"
 
     h2 "running audit for secrets"
     detect-secrets audit .secrets.baseline
-    rc=$? 
+    rc=$?
     check_exit_code $rc "Failed to audit detect-secrets."
-    
+
     #Check all secrets have been audited
     secrets=$(grep -c hashed_secret .secrets.baseline)
     audits=$(grep -c is_secret .secrets.baseline)
-    if [[ "$secrets" != "$audits" ]]; then 
+    if [[ "$secrets" != "$audits" ]]; then
         error "Not all secrets found have been audited"
-        exit 1  
+        exit 1
     fi
     sed -i '' '/[ ]*"generated_at": ".*",/d' .secrets.baseline
     success "secrets audit complete"

--- a/dependency-download/build.gradle
+++ b/dependency-download/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 // Note: The following version number is updated using the set-version.sh tool.
 // It is used as the version number of the managers bundle, which contains a yaml
-// file which is in a release.yaml, but published to maven, so that the OBR build 
+// file which is in a release.yaml, but published to maven, so that the OBR build
 // can pick it up later.
 version = "0.37.0"
 
@@ -22,6 +22,8 @@ repositories {
 dependencies {
     runtimeOnly group: 'dev.galasa', name: 'dev.galasa.managers.manifest', version: version, ext: "yaml"
     runtimeOnly group: 'dev.galasa', name: 'dev.galasa.framework.manifest', version: version, ext: "yaml"
+    runtimeOnly group: 'dev.galasa', name: 'dev.galasa.extensions.manifest', version: version, ext: "yaml"
+
 }
 
 // Download all the files we depend upon.


### PR DESCRIPTION
The OBR script seems to set the value of GALASA_BUILD_TOOL_PATH using the get_galasabld_binary_location method, then overwrite that value for each method that uses galasabld. This causes the script to fail for me when galasabld is on my path. I've removed the extra setting of GALASA_BUILD_TOOL_PATH and used the value obtained by get_galasabld_binary_location.

For each mvn call I've added:
    --settings ${WORKSPACE_DIR}/obr/settings.xml \
    -Dgpg.skip=true \

So that maven uses the settings.xml file in the workspace, allowing the value of galasa.source.repo and galasa.central.repo to be use (otherwise this fails for me).

I've also skipped gpg signing here as the maven calls seem to only pull from remote Maven and build to local Maven - signing didn't seem necessary here.