### PR TITLE
Add simplatform into build chain

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -557,8 +557,8 @@ jobs:
             dockerRepository=${{ env.REGISTRY }}
             platform=x86_64
 
-  trigger-workflow:
-    name: Trigger workflow depending upon the branch
+  trigger-next-workflows:
+    name: Trigger next workflows in the build chain
     needs: [build-obr, build-obr-generic, build-obr-javadocs]
     runs-on: ubuntu-latest
 
@@ -576,3 +576,9 @@ jobs:
            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
           gh workflow run build.yml --repo https://github.com/galasa-dev/cli --ref ${{ env.BRANCH }}
+
+      - name: Triggering simplatform build
+        env:
+           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -582,3 +582,16 @@ jobs:
            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
           gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
+
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic, trigger-next-workflows]
+    if: failure()
+
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "obr" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"


### PR DESCRIPTION
## Why?

As simplatform's build points at the obr's maven repo for its sourceMaven location, it should be rebuilt after the obr, so it can be rebuilt with the latest code and in case there are breaking changes introduced.