### PR TITLE
Build the integratedtests after the OBR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -569,6 +569,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
          gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation --ref ${{ env.BRANCH }}
+
+      - name: Triggering integratedtests build (github.ref is main)
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+         gh workflow run build.yaml --repo https://github.com/galasa-dev/integratedtests --ref ${{ env.BRANCH }}
         
       - name: Triggering cli build (github.ref is not main) 
         if: ${{ env.BRANCH != 'main' }}


### PR DESCRIPTION
## Why?

The integratedtests should be rebuilt after the OBR is so that they have the latest Manager code, and latest galasa-bom to extract the versions from. 