### PR TITLE
Fixing test failures - Add snakeyaml dependency to MVP

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -273,6 +273,7 @@ external:
     version: 2.0
     obr: true
     isolated: true
+    mvp: true
 
   - group: org.bouncycastle
     artifact: bcpkix-jdk18on


### PR DESCRIPTION
## Why?

The tests in our suite that use the MVP zipped distribution of Galasa are currently failing. The snakeyaml dependency is not part of the MVP zip and so when these tests attempt to pull the artefact, they have to reach out to Maven Central. At this point, they are getting a timeout and so the test is failing.

This PR adds snakeyaml into the MVP zip so that this failure hopefully doesn't reoccur. Not sure why the timeout when contacting Maven Central is happening, but any MVP tests shouldn't need to contact it anyway.
